### PR TITLE
Switch from one command to another without intermediate "stop" click

### DIFF
--- a/kilogui/kilowindow.cpp
+++ b/kilogui/kilowindow.cpp
@@ -188,6 +188,7 @@ QGroupBox *KiloWindow::createCommands() {
             layout->addWidget(button, i, 0);
         }
         mapper->setMapping(button, (int)KILO_COMMANDS[i].type);
+        QObject::connect(button, SIGNAL(pressed()), this, SLOT(stopSending()));
         QObject::connect(button, SIGNAL(clicked()), mapper, SLOT(map()));
     }
     QObject::connect(mapper, SIGNAL(mapped(int)), this, SLOT(sendMessage(int)));
@@ -363,7 +364,6 @@ void KiloWindow::sendMessage(int type_int) {
     } else  {
         if (sending) {
             stopSending();
-            return;
         }
 
         if (type == COMMAND_LEDTOGGLE) {


### PR DESCRIPTION
I don't know if it's intended behavior or not, but clicking on a button when another is selected just stops the current command, but doesn't start the one corresponding to the button. This fixes the problem by stopping the current command as soon as the button is pressed down.
